### PR TITLE
Specify compiler to workaround Travis/bcrypt issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,3 +3,12 @@ node_js:
   - "4"
   - "5"
 sudo: false
+env:
+  - CXX=g++-4.8
+addons:
+  apt:
+    sources:
+      - ubuntu-toolchain-r-test
+    packages:
+      - gcc-4.8
+      - g++-4.8


### PR DESCRIPTION
There’s some problems compiling bcrypt on Travis because of a compiler version.  This appears to be the workaround which is necessary until it’s provided by default in Travis.  More information can be found in this issue:
https://github.com/travis-ci/travis-ci/issues/4771