### PR TITLE
Upgrade mongoose

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "history": "1.17.0",
     "isomorphic-fetch": "2.2.1",
     "lodash": "4.0.0",
-    "mongoose": "4.3.6",
+    "mongoose": "4.4.12",
     "passport": "0.3.2",
     "passport-local": "1.0.0",
     "react": "0.14.6",


### PR DESCRIPTION
To avoid potential errors with peer dependencies, update to the latest version.