### PR TITLE
Use history middleware for webpack dev mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "async": "1.5.2",
     "bcrypt": "0.8.5",
     "body-parser": "1.15.0",
+    "connect-history-api-fallback": "1.2.0",
     "cookie-session": "1.2.0",
     "debug-caller": "2.1.0",
     "express": "4.13.3",


### PR DESCRIPTION
When running in development mode, we use the webpack dev middleware which stores the bundle in memory and responds to HTTP requests on a certain url (/).  This causes problems when we use the history API in the client and send the user to pages other than /.  When this happens, if the user was to refresh the page or directly request those other URLs, they would get a 404.

To avoid this problem, use the history middleware which rewrites all html requests to the root url.  We should only do this in non-production mode though, since in non-production mode we don’t use the webpack dev middleware and things work as normal.