### PR TITLE
Load more movies

### DIFF
--- a/app/actions/movie.actions.js
+++ b/app/actions/movie.actions.js
@@ -24,10 +24,17 @@ function moviesLoaded(movies) {
 }
 
 export function loadMovies() {
-  return dispatch => {
+  return (dispatch, getState) => {
     dispatch(moviesLoading());
 
-    return fetch('/api/secure/movies', {
+    const moviesState = getState().moviesState;
+    const movies = moviesState.movies;
+    const skip = moviesState.skip;
+    const limit = moviesState.limit;
+
+    const uri = `/api/secure/movies?skip=${skip}&limit=${limit}`;
+
+    return fetch(uri, {
       method: 'GET',
       headers: {
         Accept: 'application/json',
@@ -37,7 +44,10 @@ export function loadMovies() {
     })
     .then(checkHttpStatus)
     .then(response => response.json())
-    .then(json => dispatch(moviesLoaded(json)))
+    .then(newMovies => {
+      const updatedMovies = movies.concat(newMovies);
+      return dispatch(moviesLoaded(updatedMovies));
+    })
     .catch((error) => handleHttpError(dispatch, error, failedLoadingMovies));
   };
 }

--- a/app/base.scss
+++ b/app/base.scss
@@ -1,0 +1,11 @@
+.button-default {
+  padding: 0.5rem 1rem;
+  border-radius: 3px;
+  margin: 0 1rem;
+  border: 0;
+  background: $swatch01;
+  min-width: 70px;
+}
+.button-with-hover:hover {
+  cursor: pointer;
+}

--- a/app/components/movie/movie.component.scss
+++ b/app/components/movie/movie.component.scss
@@ -60,13 +60,5 @@
   margin-top: 0.75rem;
 }
 .button {
-  padding: 0.5rem 1rem;
-  border-radius: 3px;
-  margin: 0 1rem;
-  border: 0;
-  background: $swatch01;
-  min-width: 70px;
-  &:hover {
-    cursor: pointer;
-  }
+  composes: button-default button-with-hover from '../../base.scss';
 }

--- a/app/components/movies/movies.component.js
+++ b/app/components/movies/movies.component.js
@@ -1,26 +1,25 @@
-import React, { Component, PropTypes } from 'react';
+import React, { PropTypes } from 'react';
+
+import style from './movies.component.scss';
 
 import MovieContainer from '../../containers/movie/movie.container';
 
-export default class Movies extends Component {
-  componentWillMount() {
-    this.props.loadMovies();
-  }
+export default function Movies(props) {
+  const moviesToRender = props.movies.map(movie =>
+    <MovieContainer key={movie.id} movie={movie} />
+  );
 
-  render() {
-    const moviesToRender = this.props.movies.map(movie =>
-      <MovieContainer key={movie.id} movie={movie} />
-    );
-
-    return (
-      <div>
-        {moviesToRender}
+  return (
+    <div>
+      {moviesToRender}
+      <div className={style.buttons}>
+        <button className={style.button} onClick={::props.loadMoreMovies}>Load More</button>
       </div>
-    );
-  }
+    </div>
+  );
 }
 
 Movies.propTypes = {
-  loadMovies: PropTypes.func.isRequired,
+  loadMoreMovies: PropTypes.func.isRequired,
   movies: PropTypes.array.isRequired,
 };

--- a/app/components/movies/movies.component.scss
+++ b/app/components/movies/movies.component.scss
@@ -1,0 +1,7 @@
+.buttons {
+  text-align: center;
+  margin-top: 0.75rem;
+}
+.button {
+  composes: button-default button-with-hover from '../../base.scss';
+}

--- a/app/containers/movies/movies.container.js
+++ b/app/containers/movies/movies.container.js
@@ -1,14 +1,24 @@
-import React, { PropTypes } from 'react';
+import React, { Component, PropTypes } from 'react';
 import { bindActionCreators } from 'redux';
 import { connect } from 'react-redux';
 
 import Movies from '../../components/movies/movies.component';
 import * as MovieActions from '../../actions/movie.actions';
 
-function MoviesContainer({ moviesState, movieActions }) {
-  return (
-    <Movies loadMovies={movieActions.loadMovies} movies={moviesState.movies} />
-  );
+class MoviesContainer extends Component {
+  componentWillMount() {
+    // to start, let's load some movies
+    this.props.movieActions.loadMovies();
+  }
+
+  render() {
+    return (
+      <Movies
+        loadMoreMovies={this.props.movieActions.loadMovies}
+        movies={this.props.moviesState.movies}
+      />
+    );
+  }
 }
 
 MoviesContainer.propTypes = {
@@ -18,7 +28,7 @@ MoviesContainer.propTypes = {
 
 function mapStateToProps(state) {
   return {
-    moviesState: state.movies,
+    moviesState: state.moviesState,
   };
 }
 

--- a/app/reducers/movies.reducer.js
+++ b/app/reducers/movies.reducer.js
@@ -6,6 +6,8 @@ import {
 
 const initialState = {
   isWaiting: false,
+  skip: 0,
+  limit: 20,
   movies: [],
   error: null,
 };
@@ -20,6 +22,8 @@ export default function movies(state = initialState, action) {
     case MOVIES_LOADED:
       return Object.assign({}, state, {
         isWaiting: false,
+        // increase the skip by the amount we've requested
+        skip: state.skip + state.limit,
         movies: action.movies,
         error: null,
       });

--- a/app/reducers/root.reducer.js
+++ b/app/reducers/root.reducer.js
@@ -1,10 +1,10 @@
 import { combineReducers } from 'redux';
 import { routerReducer as routing } from 'react-router-redux';
 import loginReducer from './login.reducer';
-import movies from './movies.reducer';
+import moviesReducer from './movies.reducer';
 
 export default combineReducers({
   routing,
   loginState: loginReducer,
-  movies,
+  moviesState: moviesReducer,
 });

--- a/test/app/actions/movie.actions.test.js
+++ b/test/app/actions/movie.actions.test.js
@@ -13,7 +13,13 @@ describe('movieActions', () => {
   let store;
 
   beforeEach(() => {
-    store = mockStore();
+    store = mockStore({
+      moviesState: {
+        movies: [{ z: 9 }],
+        skip: 0,
+        limit: 20,
+      },
+    });
   });
 
   afterEach(() => {
@@ -25,7 +31,7 @@ describe('movieActions', () => {
   });
 
   describe('loadMovies', () => {
-    const LOAD_MOVIES_API = '/api/secure/movies';
+    const LOAD_MOVIES_API = '/api/secure/movies?skip=0&limit=20';
 
     describe('when movies are returned', () => {
       let MOVIES;
@@ -39,7 +45,11 @@ describe('movieActions', () => {
       it('should return the correct actions', (done) => {
         const expectedActions = [
           { type: types.LOADING_MOVIES, payload: undefined },
-          { type: types.MOVIES_LOADED, movies: MOVIES },
+          { type: types.MOVIES_LOADED, movies: [
+            { z: 9 },
+            { a: 1 },
+            { b: 2 },
+          ] },
         ];
 
         store.dispatch(movieActions.loadMovies())

--- a/test/app/reducers/movies.reducer.test.js
+++ b/test/app/reducers/movies.reducer.test.js
@@ -10,6 +10,8 @@ describe('movies reducer', () => {
   it('should have to correct initial state', () => {
     should(reducer(undefined, {})).deepEqual({
       isWaiting: false,
+      skip: 0,
+      limit: 20,
       movies: [],
       error: null,
     });
@@ -29,6 +31,8 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: true,
+        skip: 0,
+        limit: 20,
         movies: [],
         error: null,
       });
@@ -53,6 +57,8 @@ describe('movies reducer', () => {
           })
         ).deepEqual({
           isWaiting: false,
+          skip: 20,
+          limit: 20,
           movies: [
             {
               a: 1,
@@ -70,6 +76,8 @@ describe('movies reducer', () => {
           })
         ).deepEqual({
           isWaiting: false,
+          skip: 0,
+          limit: 20,
           movies: [],
           error: 'FAIL!',
         });


### PR DESCRIPTION
Provide a way for the movies component to load more movies.  Change the movies component to be a dumb component, and move that logic to the container.  The movies component now requests a function that is used to load “more” movies.

To accomplish this, the movie actions now requests the current state, and bases the load movies API call off of the known skip and limit within the state.  The movies reducer then updates the skip adding to it the limit.  (This will probably need to be changed in the future, but works for now.)

Some CSS refactoring was done to share some code between components. Added a `base.scss` to include generic stylings used by the components.