### PR TITLE
Dismiss movie API

### DIFF
--- a/server/api/controllers/movies.controller.js
+++ b/server/api/controllers/movies.controller.js
@@ -1,6 +1,12 @@
 import util from 'util';
 
-import { loadMovies, downloadMovieData } from '../../lib/movies';
+const logger = require('../../lib/logger')();
+
+import {
+  loadMovies,
+  downloadMovieData,
+  dismissMovie,
+} from '../../lib/movies';
 
 function handleError(err, res) {
   return res.status(500).send({
@@ -12,7 +18,7 @@ export function getMovies(req, res) {
   const skip = req.query.skip;
   const limit = req.query.limit;
 
-  loadMovies({
+  loadMovies({}, {
     skip,
     limit,
   }, (err, movies) => {
@@ -28,4 +34,22 @@ export function pullMovieData(req, res) {
 
     return res.send(stats);
   });
+}
+
+export function updateMovie(req, res) {
+  const movieId = req.params.movieId;
+  const body = req.body;
+
+  logger.log('updateMovie: body: ', body);
+
+  // we allow dismissing a movie only
+  if (body.dismissed) {
+    return dismissMovie(movieId, (err, movie) => {
+      if (err) { return handleError(err, res); }
+
+      return res.send(movie);
+    });
+  } else {
+    return res.status(400).end();
+  }
 }

--- a/server/api/routes/movies.routes.js
+++ b/server/api/routes/movies.routes.js
@@ -1,6 +1,12 @@
-import { getMovies, pullMovieData } from '../controllers/movies.controller';
+import {
+  getMovies,
+  pullMovieData,
+  updateMovie,
+} from '../controllers/movies.controller';
 
 module.exports = (router) => {
   router.route('/api/secure/movies').get(getMovies);
+  router.route('/api/secure/movies/:movieId').patch(updateMovie);
+
   router.route('/api/secure/download-movie-data').get(pullMovieData);
 };

--- a/server/lib/movies.js
+++ b/server/lib/movies.js
@@ -288,14 +288,19 @@ export function downloadMovieData(callback) {
 /**
  * Returns the movies from our internal database, modified to fit the UI
  */
-export function loadMovies(options, callback) {
-  // take the user input and add our default options if needed
+export function loadMovies(conditions, options, callback) {
+  // apply the user conditions to our defaults
+  _.defaults(conditions, {
+    dismissed: false,
+  });
+
+  // apply the user options to our defaults
   _.defaults(options, {
     skip: 0,
     limit: 20,
   });
 
-  return Movie.find({}, null, options, (findErr, movies) => {
+  return Movie.find(conditions, null, options, (findErr, movies) => {
     if (findErr) { return callback(findErr); }
 
     // build the movies UI list by parsing each movie
@@ -303,4 +308,13 @@ export function loadMovies(options, callback) {
 
     return callback(null, moviesUI);
   });
+}
+
+export function dismissMovie(movieId, callback) {
+  logger.log(`dismissMovie: movieId: ${movieId}`);
+  return Movie.findByIdAndUpdate(movieId, {
+    dismissed: true,
+  }, {
+    new: true,
+  }, callback);
 }

--- a/server/models/movie.js
+++ b/server/models/movie.js
@@ -55,4 +55,31 @@ MovieSchema.pre('save', function storeTitleAsId(next) {
   return next();
 });
 
+// pre-save hook for providing defaults for saved and dismissed
+MovieSchema.pre('save', function provideDefaults(next) {
+  const movie = this;
+
+  if (movie.isNew) {
+    logger.log('pre-save hook for providing defaults');
+
+    // saved must be true or false
+    if (!movie.saved) {
+      logger.log('pre-save hook for providing defaults: defaulting saved to false');
+      movie.saved = false;
+    }
+
+    // dismissed must be true or false
+    if (!movie.dismissed) {
+      logger.log('pre-save hook for providing defaults: defaulting dismissed to false');
+      movie.dismissed = false;
+    }
+
+    logger.log('pre-save hook for providing defaults complete');
+  } else {
+    logger.log('pre-save hook for providing defaults skipped, document is not new');
+  }
+
+  return next();
+});
+
 mongoose.model('Movie', MovieSchema);

--- a/test/server/lib/movies.test.js
+++ b/test/server/lib/movies.test.js
@@ -388,4 +388,94 @@ describe('The movies library', () => {
       });
     });
   });
+
+  describe('loadMovies', () => {
+    let MOVIES;
+    let Movie;
+
+    beforeEach(() => {
+      MOVIES = [{ a: 1 }, { b: 2 }];
+
+      Movie = {
+        _conditions: null,
+        _options: null,
+        find(conditions, projection, options, callback) {
+          this._conditions = conditions;
+          this._options = options;
+          return callback(null, MOVIES);
+        },
+      };
+
+      moviesLib.__set__('Movie', Movie);
+
+      moviesLib.__set__('buildMovieUI', (movie) => movie);
+    });
+
+    it('should work with defaults', () => {
+      moviesLib.loadMovies({}, {}, (err, moviesUI) => {
+        should(err).be.null();
+        should(moviesUI).deepEqual(MOVIES);
+
+        should(Movie._conditions).deepEqual({
+          dismissed: false,
+        });
+        should(Movie._options).deepEqual({
+          skip: 0,
+          limit: 20,
+        });
+      });
+    });
+
+    it('should allow for overrides of conditions/options', () => {
+      moviesLib.loadMovies({
+        dismissed: true,
+      }, {
+        skip: 12,
+        limit: 2,
+      }, (err, moviesUI) => {
+        should(err).be.null();
+        should(moviesUI).deepEqual(MOVIES);
+
+        should(Movie._conditions).deepEqual({
+          dismissed: true,
+        });
+        should(Movie._options).deepEqual({
+          skip: 12,
+          limit: 2,
+        });
+      });
+    });
+  });
+
+  describe('dismissMovie', () => {
+    let Movie;
+
+    beforeEach(() => {
+      Movie = {
+        _id: null,
+        _updates: null,
+        _options: null,
+        findByIdAndUpdate(id, updates, options, callback) {
+          this._id = id;
+          this._updates = updates;
+          this._options = options;
+          return callback();
+        },
+      };
+
+      moviesLib.__set__('Movie', Movie);
+    });
+
+    it('should work with defaults', () => {
+      moviesLib.dismissMovie('123', () => {
+        should(Movie._id).equal('123');
+        should(Movie._updates).deepEqual({
+          dismissed: true,
+        });
+        should(Movie._options).deepEqual({
+          new: true,
+        });
+      });
+    });
+  });
 });


### PR DESCRIPTION
Provide an API which grants the user the ability to update a movie, specifically dismissing a movie.  This simply marks a flag on the movie document.  Subsequent loads of movies will (by default) not include dismissed movies.

In order to assure that we have an even playing field, all movies should default `false` as the dismissed and saved flags (if they are not set to begin with).