### PR TITLE
Use Node v6 in Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: node_js
 node_js:
-  - "4"
-  - "5"
+  - "6"
 sudo: false
 env:
   - CXX=g++-4.8


### PR DESCRIPTION
Use the latest version of Node (much faster) and remove the others.