### PR TITLE
Hide header on login page

### DIFF
--- a/app/components/login/login.component.js
+++ b/app/components/login/login.component.js
@@ -44,6 +44,7 @@ export default class Login extends Component {
         <div className={style.heading}>Login</div>
         <form>
           <input
+            autoFocus
             className={style.input}
             name="username"
             placeholder="Username"

--- a/app/containers/app/app.container.js
+++ b/app/containers/app/app.container.js
@@ -1,13 +1,13 @@
 import React, { PropTypes } from 'react';
-import { connect } from 'react-redux';
 
 import HeaderContainer from '../header/header.container';
 
 import style from './app.container.scss';
 
-function App({ children, loginState }) {
+export default function App({ children, location }) {
+  // don't show the header on the login page
   let header;
-  if (loginState.user) {
+  if (location.pathname !== '/login') {
     header = (
       <HeaderContainer />
     );
@@ -25,13 +25,5 @@ function App({ children, loginState }) {
 
 App.propTypes = {
   children: PropTypes.any,
-  loginState: PropTypes.object.isRequired,
+  location: PropTypes.object.isRequired,
 };
-
-function mapStateToProps(state) {
-  return {
-    loginState: state.loginState,
-  };
-}
-
-export default connect(mapStateToProps)(App);


### PR DESCRIPTION
Use the location path to determine if we should show/hide the header. The login state was not enough, since it would be reset if the user refreshed the page or started already logged in and visited an “inside” page.