### PR TITLE
Remove redux-actions

### DIFF
--- a/app/actions/login.actions.js
+++ b/app/actions/login.actions.js
@@ -1,4 +1,3 @@
-import { createAction } from 'redux-actions';
 import { push } from 'react-router-redux';
 
 import { FETCH_DEFAULT_OPTIONS } from '../utils/http.utils';
@@ -8,7 +7,9 @@ import {
   LOGIN_ERROR,
 } from '../action-types/login.action-types';
 
-const loginInitiated = createAction(LOGIN_INITIATED);
+function loginInitiated() {
+  return { type: LOGIN_INITIATED };
+}
 
 function loginSuccess(user) {
   return {

--- a/app/actions/movie.actions.js
+++ b/app/actions/movie.actions.js
@@ -1,4 +1,3 @@
-import { createAction } from 'redux-actions';
 import { remove, unionBy } from 'lodash';
 
 import {
@@ -23,11 +22,25 @@ import {
   FAILED_UPDATING_MOVIE,
 } from '../action-types/movie.action-types';
 
-const loadingMovies = createAction(LOADING_MOVIES);
-const moviesAlreadyLoaded = createAction(MOVIES_ALREADY_LOADED);
-const savingMovie = createAction(SAVING_MOVIE);
-const dismissingMovie = createAction(DISMISSING_MOVIE);
-const undismissingMovie = createAction(UNDISMISSING_MOVIE);
+function loadingMovies() {
+  return { type: LOADING_MOVIES };
+}
+
+function moviesAlreadyLoaded() {
+  return { type: MOVIES_ALREADY_LOADED };
+}
+
+function savingMovie() {
+  return { type: SAVING_MOVIE };
+}
+
+function dismissingMovie() {
+  return { type: DISMISSING_MOVIE };
+}
+
+function undismissingMovie() {
+  return { type: UNDISMISSING_MOVIE };
+}
 
 function failedLoadingMovies(error) {
   return {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "react-router": "2.4.0",
     "react-router-redux": "4.0.4",
     "redux": "3.5.2",
-    "redux-actions": "0.9.1",
     "redux-logger": "2.6.1",
     "redux-thunk": "2.0.1",
     "request": "2.72.0",

--- a/test/app/actions/login.actions.test.js
+++ b/test/app/actions/login.actions.test.js
@@ -32,7 +32,7 @@ describe('loginActions', () => {
 
       beforeEach(() => {
         expectedActions = [
-          { type: types.LOGIN_INITIATED, payload: undefined },
+          { type: types.LOGIN_INITIATED },
           { type: types.LOGIN_ERROR, error: 'Please enter a username and password.' },
         ];
       });
@@ -60,7 +60,7 @@ describe('loginActions', () => {
 
       it('should return login error', (done) => {
         const expectedActions = [
-          { type: types.LOGIN_INITIATED, payload: undefined },
+          { type: types.LOGIN_INITIATED },
           { type: types.LOGIN_ERROR, error: 'Incorrect username or password.' },
         ];
 
@@ -91,7 +91,7 @@ describe('loginActions', () => {
             const actions = store.getActions();
 
             should(actions.length).equal(3);
-            should(actions[0]).deepEqual({ type: types.LOGIN_INITIATED, payload: undefined });
+            should(actions[0]).deepEqual({ type: types.LOGIN_INITIATED });
             should(actions[1]).deepEqual({ type: types.LOGIN_SUCCESS, user: { username } });
             should(actions[2].payload.args).deepEqual(['/']);
           })

--- a/test/app/actions/movie.actions.test.js
+++ b/test/app/actions/movie.actions.test.js
@@ -41,7 +41,7 @@ describe('movieActions', () => {
       it('should return the correct state', () => {
         store.dispatch(movieActions.loadInitialMoviesQueue());
         should(store.getActions()).deepEqual([
-          { type: types.MOVIES_ALREADY_LOADED, payload: undefined },
+          { type: types.MOVIES_ALREADY_LOADED },
         ]);
       });
     });
@@ -62,7 +62,7 @@ describe('movieActions', () => {
       it('should return the correct state', () => {
         store.dispatch(movieActions.loadInitialSavedMovies());
         should(store.getActions()).deepEqual([
-          { type: types.MOVIES_ALREADY_LOADED, payload: undefined },
+          { type: types.MOVIES_ALREADY_LOADED },
         ]);
       });
     });
@@ -83,7 +83,7 @@ describe('movieActions', () => {
       it('should return the correct state', () => {
         store.dispatch(movieActions.loadInitialDismissedMovies());
         should(store.getActions()).deepEqual([
-          { type: types.MOVIES_ALREADY_LOADED, payload: undefined },
+          { type: types.MOVIES_ALREADY_LOADED },
         ]);
       });
     });
@@ -103,14 +103,17 @@ describe('movieActions', () => {
 
       it('should return the correct actions', (done) => {
         const expectedActions = [
-          { type: types.LOADING_MOVIES, payload: undefined },
-          { type: types.MOVIES_QUEUE_LOADED, moviesQueue: [
-            { id: 'a' },
-            { id: 'b' },
-            { id: 'c' },
-            { id: 'x' },
-            { id: 'y' },
-          ] },
+          { type: types.LOADING_MOVIES },
+          {
+            type: types.MOVIES_QUEUE_LOADED,
+            moviesQueue: [
+              { id: 'a' },
+              { id: 'b' },
+              { id: 'c' },
+              { id: 'x' },
+              { id: 'y' },
+            ],
+          },
         ];
 
         store.dispatch(movieActions.loadMoviesQueue())
@@ -136,12 +139,15 @@ describe('movieActions', () => {
           store.dispatch(movieActions.loadInitialMoviesQueue())
             .then(() => {
               should(store.getActions()).deepEqual([
-                { type: types.LOADING_MOVIES, payload: undefined },
-                { type: types.MOVIES_QUEUE_LOADED, moviesQueue: [
-                  { id: 'x' },
-                  { id: 'y' },
-                  { id: 'c' },
-                ] },
+                { type: types.LOADING_MOVIES },
+                {
+                  type: types.MOVIES_QUEUE_LOADED,
+                  moviesQueue: [
+                    { id: 'x' },
+                    { id: 'y' },
+                    { id: 'c' },
+                  ],
+                },
               ]);
             })
             .then(done)   // testing complete
@@ -203,14 +209,17 @@ describe('movieActions', () => {
 
       it('should return the correct actions', (done) => {
         const expectedActions = [
-          { type: types.LOADING_MOVIES, payload: undefined },
-          { type: types.SAVED_MOVIES_LOADED, savedMovies: [
-            { id: 'd' },
-            { id: 'e' },
-            { id: 'f' },
-            { id: 'x' },
-            { id: 'y' },
-          ] },
+          { type: types.LOADING_MOVIES },
+          {
+            type: types.SAVED_MOVIES_LOADED,
+            savedMovies: [
+              { id: 'd' },
+              { id: 'e' },
+              { id: 'f' },
+              { id: 'x' },
+              { id: 'y' },
+            ],
+          },
         ];
 
         store.dispatch(movieActions.loadSavedMovies())
@@ -236,12 +245,15 @@ describe('movieActions', () => {
           store.dispatch(movieActions.loadInitialSavedMovies())
             .then(() => {
               should(store.getActions()).deepEqual([
-                { type: types.LOADING_MOVIES, payload: undefined },
-                { type: types.SAVED_MOVIES_LOADED, savedMovies: [
-                  { id: 'x' },
-                  { id: 'y' },
-                  { id: 'f' },
-                ] },
+                { type: types.LOADING_MOVIES },
+                {
+                  type: types.SAVED_MOVIES_LOADED,
+                  savedMovies: [
+                    { id: 'x' },
+                    { id: 'y' },
+                    { id: 'f' },
+                  ],
+                },
               ]);
             })
             .then(done)   // testing complete
@@ -265,14 +277,17 @@ describe('movieActions', () => {
 
       it('should return the correct actions', (done) => {
         const expectedActions = [
-          { type: types.LOADING_MOVIES, payload: undefined },
-          { type: types.DISMISSED_MOVIES_LOADED, dismissedMovies: [
-            { id: 'g' },
-            { id: 'h' },
-            { id: 'i' },
-            { id: 'x' },
-            { id: 'y' },
-          ] },
+          { type: types.LOADING_MOVIES },
+          {
+            type: types.DISMISSED_MOVIES_LOADED,
+            dismissedMovies: [
+              { id: 'g' },
+              { id: 'h' },
+              { id: 'i' },
+              { id: 'x' },
+              { id: 'y' },
+            ],
+          },
         ];
 
         store.dispatch(movieActions.loadDismissedMovies())
@@ -298,12 +313,15 @@ describe('movieActions', () => {
           store.dispatch(movieActions.loadInitialDismissedMovies())
             .then(() => {
               should(store.getActions()).deepEqual([
-                { type: types.LOADING_MOVIES, payload: undefined },
-                { type: types.DISMISSED_MOVIES_LOADED, dismissedMovies: [
-                  { id: 'x' },
-                  { id: 'y' },
-                  { id: 'i' },
-                ] },
+                { type: types.LOADING_MOVIES },
+                {
+                  type: types.DISMISSED_MOVIES_LOADED,
+                  dismissedMovies: [
+                    { id: 'x' },
+                    { id: 'y' },
+                    { id: 'i' },
+                  ],
+                },
               ]);
             })
             .then(done)   // testing complete
@@ -323,7 +341,7 @@ describe('movieActions', () => {
 
       it('should return the correct actions', (done) => {
         const expectedActions = [
-          { type: types.SAVING_MOVIE, payload: undefined },
+          { type: types.SAVING_MOVIE },
           {
             type: types.SAVED_MOVIE,
             moviesQueue: [{ id: 'b' }, { id: 'c' }],
@@ -371,7 +389,7 @@ describe('movieActions', () => {
 
       it('should return the correct actions (moviesQueue)', (done) => {
         const expectedActions = [
-          { type: types.DISMISSING_MOVIE, payload: undefined },
+          { type: types.DISMISSING_MOVIE },
           {
             type: types.DISMISSED_MOVIE,
             moviesQueue: [{ id: 'b' }, { id: 'c' }],
@@ -390,7 +408,7 @@ describe('movieActions', () => {
 
       it('should return the correct actions (savedMovies)', (done) => {
         const expectedActions = [
-          { type: types.DISMISSING_MOVIE, payload: undefined },
+          { type: types.DISMISSING_MOVIE },
           {
             type: types.DISMISSED_MOVIE,
             moviesQueue: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
@@ -447,7 +465,7 @@ describe('movieActions', () => {
 
       it('should return the correct actions (moviesQueue)', (done) => {
         const expectedActions = [
-          { type: types.UNDISMISSING_MOVIE, payload: undefined },
+          { type: types.UNDISMISSING_MOVIE },
           {
             type: types.UNDISMISSED_MOVIE,
             moviesQueue: [
@@ -470,7 +488,7 @@ describe('movieActions', () => {
 
       it('should return the correct actions (savedMovies)', (done) => {
         const expectedActions = [
-          { type: types.UNDISMISSING_MOVIE, payload: undefined },
+          { type: types.UNDISMISSING_MOVIE },
           {
             type: types.UNDISMISSED_MOVIE,
             moviesQueue: [{ id: 'a', saved: false }, { id: 'b', saved: false }],


### PR DESCRIPTION
There’s really not a lot saved from using the `redux-actions` `createAction`.  It kinda makes things a bit more difficult to parse when looking at the actions.  So remove it in place of the function with type specified.