### PR TITLE
Move movie action logic to reducer

### DIFF
--- a/app/reducers/movies.reducer.js
+++ b/app/reducers/movies.reducer.js
@@ -1,3 +1,5 @@
+import { differenceBy, unionBy, find } from 'lodash';
+
 import {
   LOADING_MOVIES,
   MOVIES_QUEUE_LOADED,
@@ -72,39 +74,84 @@ export default function movies(state = initialState, action) {
         isWaiting: true,
         error: null,
       });
-    case SAVED_MOVIE:
+    case SAVED_MOVIE: {
+      // remove the movie from our movies queue, and add it to the saved movies
+      const { moviesQueue, savedMovies } = state;
+      const updatedMoviesQueue = differenceBy(moviesQueue, [action.updatedMovie], 'id');
+      const updatedSavedMovies = unionBy(savedMovies, [action.updatedMovie], 'id');
+
       return Object.assign({}, state, {
         isWaiting: false,
-        moviesQueue: action.moviesQueue,
-        savedMovies: action.savedMovies,
+        moviesQueue: updatedMoviesQueue,
+        savedMovies: updatedSavedMovies,
         error: null,
       });
+    }
+
     case DISMISSING_MOVIE:
       return Object.assign({}, state, {
         isWaiting: true,
         error: null,
       });
-    case DISMISSED_MOVIE:
+    case DISMISSED_MOVIE: {
+      // remove the movie from either the movies queue or saved movies, and
+      // add the movie to our dismissed movies
+      const { moviesQueue, savedMovies, dismissedMovies } = state;
+
+      let updatedMoviesQueue;
+      let updatedSavedMovies;
+      // where are you movie?
+      if (find(moviesQueue, ['id', action.updatedMovie.id])) {
+        // you're in the movies queue!
+        updatedMoviesQueue = differenceBy(moviesQueue, [action.updatedMovie], 'id');
+        updatedSavedMovies = savedMovies;
+      } else {
+        // you're in the saved movies!
+        updatedMoviesQueue = moviesQueue;
+        updatedSavedMovies = differenceBy(savedMovies, [action.updatedMovie], 'id');
+      }
+      const updatedDismissedMovies = unionBy(dismissedMovies, [action.updatedMovie], 'id');
+
       return Object.assign({}, state, {
         isWaiting: false,
-        moviesQueue: action.moviesQueue,
-        savedMovies: action.savedMovies,
-        dismissedMovies: action.dismissedMovies,
+        moviesQueue: updatedMoviesQueue,
+        savedMovies: updatedSavedMovies,
+        dismissedMovies: updatedDismissedMovies,
         error: null,
       });
+    }
     case UNDISMISSING_MOVIE:
       return Object.assign({}, state, {
         isWaiting: true,
         error: null,
       });
-    case UNDISMISSED_MOVIE:
+    case UNDISMISSED_MOVIE: {
+      // remove the movie from the dismissed movies and add it to either the
+      // movies queue or the saved movies based on the saved flag
+      // remove the movie from either the movies queue or saved movies, and
+      // add the movie to our dismissed movies
+      const { moviesQueue, savedMovies, dismissedMovies } = state;
+
+      let updatedMoviesQueue;
+      let updatedSavedMovies;
+      // was this movie saved before it was dismissed?
+      if (action.updatedMovie.saved) {
+        updatedMoviesQueue = moviesQueue;
+        updatedSavedMovies = unionBy(savedMovies, [action.updatedMovie], 'id');
+      } else {
+        updatedMoviesQueue = unionBy(moviesQueue, [action.updatedMovie], 'id');
+        updatedSavedMovies = savedMovies;
+      }
+      const updatedDismissedMovies = differenceBy(dismissedMovies, [action.updatedMovie], 'id');
+
       return Object.assign({}, state, {
         isWaiting: false,
-        moviesQueue: action.moviesQueue,
-        savedMovies: action.savedMovies,
-        dismissedMovies: action.dismissedMovies,
+        moviesQueue: updatedMoviesQueue,
+        savedMovies: updatedSavedMovies,
+        dismissedMovies: updatedDismissedMovies,
         error: null,
       });
+    }
     case FAILED_UPDATING_MOVIE:
       return Object.assign({}, state, {
         isWaiting: false,

--- a/server/lib/movies.js
+++ b/server/lib/movies.js
@@ -310,13 +310,19 @@ export function loadMovies(conditions, options, callback) {
   });
 }
 
+function handleEnableTagCallback(err, movie, callback) {
+  if (err) { return callback(err); }
+
+  return callback(null, buildMovieUI(movie));
+}
+
 export function enableSaved(movieId, callback) {
   logger.log(`enableSaved: movieId: ${movieId}`);
   return Movie.findByIdAndUpdate(movieId, {
     saved: true,
   }, {
     new: true,
-  }, callback);
+  }, (err, movie) => handleEnableTagCallback(err, movie, callback));
 }
 
 export function enableDismissed(movieId, callback) {
@@ -325,7 +331,7 @@ export function enableDismissed(movieId, callback) {
     dismissed: true,
   }, {
     new: true,
-  }, callback);
+  }, (err, movie) => handleEnableTagCallback(err, movie, callback));
 }
 
 export function disableDismissed(movieId, callback) {
@@ -334,5 +340,5 @@ export function disableDismissed(movieId, callback) {
     dismissed: false,
   }, {
     new: true,
-  }, callback);
+  }, (err, movie) => handleEnableTagCallback(err, movie, callback));
 }

--- a/test/app/actions/movie.actions.test.js
+++ b/test/app/actions/movie.actions.test.js
@@ -11,21 +11,21 @@ const mockStore = configureMockStore(middlewares);
 
 describe('movieActions', () => {
   let store;
+  let UPDATED_MOVIE;
 
   beforeEach(() => {
     store = mockStore({
       moviesState: {
-        moviesQueueSkip: 0,
-        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
-        savedMoviesSkip: 0,
-        savedMoviesLimit: 20,
         savedMovies: [{ id: 'd' }, { id: 'e' }, { id: 'f' }],
-        dismissedMoviesSkip: 0,
-        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'g' }, { id: 'h' }, { id: 'i' }],
       },
     });
+
+    UPDATED_MOVIE = {
+      a: 1,
+      b: 2,
+    };
   });
 
   afterEach(() => {
@@ -41,17 +41,16 @@ describe('movieActions', () => {
 
     describe('when the API call is successful', () => {
       beforeEach(() => {
-        fetchMock.mock(SAVE_MOVIE_API, 200);
+        fetchMock.mock(SAVE_MOVIE_API, {
+          body: UPDATED_MOVIE,
+          status: 200,
+        });
       });
 
       it('should return the correct actions', (done) => {
         const expectedActions = [
           { type: types.SAVING_MOVIE },
-          {
-            type: types.SAVED_MOVIE,
-            moviesQueue: [{ id: 'b' }, { id: 'c' }],
-            savedMovies: [{ id: 'd' }, { id: 'e' }, { id: 'f' }, { id: 'a' }],
-          },
+          { type: types.SAVED_MOVIE, updatedMovie: UPDATED_MOVIE },
         ];
 
         store.dispatch(movieActions.saveMovie('a'))
@@ -88,41 +87,19 @@ describe('movieActions', () => {
 
     describe('when the API call is successful', () => {
       beforeEach(() => {
-        fetchMock.mock(DISMISS_MOVIE_API, 200);
-        fetchMock.mock('/api/secure/movies/d', 200);
+        fetchMock.mock(DISMISS_MOVIE_API, {
+          body: UPDATED_MOVIE,
+          status: 200,
+        });
       });
 
-      it('should return the correct actions (moviesQueue)', (done) => {
+      it('should return the correct actions', (done) => {
         const expectedActions = [
           { type: types.DISMISSING_MOVIE },
-          {
-            type: types.DISMISSED_MOVIE,
-            moviesQueue: [{ id: 'b' }, { id: 'c' }],
-            savedMovies: [{ id: 'd' }, { id: 'e' }, { id: 'f' }],
-            dismissedMovies: [{ id: 'g' }, { id: 'h' }, { id: 'i' }, { id: 'a' }],
-          },
+          { type: types.DISMISSED_MOVIE, updatedMovie: UPDATED_MOVIE },
         ];
 
         store.dispatch(movieActions.dismissMovie('a'))
-          .then(() => {
-            should(store.getActions()).deepEqual(expectedActions);
-          })
-          .then(done)   // testing complete
-          .catch(done); // we do this in case the tests fail, to end tests
-      });
-
-      it('should return the correct actions (savedMovies)', (done) => {
-        const expectedActions = [
-          { type: types.DISMISSING_MOVIE },
-          {
-            type: types.DISMISSED_MOVIE,
-            moviesQueue: [{ id: 'a' }, { id: 'b' }, { id: 'c' }],
-            savedMovies: [{ id: 'e' }, { id: 'f' }],
-            dismissedMovies: [{ id: 'g' }, { id: 'h' }, { id: 'i' }, { id: 'd' }],
-          },
-        ];
-
-        store.dispatch(movieActions.dismissMovie('d'))
           .then(() => {
             should(store.getActions()).deepEqual(expectedActions);
           })
@@ -152,61 +129,23 @@ describe('movieActions', () => {
   });
 
   describe('undismissMovie', () => {
-    beforeEach(() => {
-      store = mockStore({
-        moviesState: {
-          moviesQueue: [{ id: 'a', saved: false }, { id: 'b', saved: false }],
-          savedMovies: [{ id: 'd', saved: true }, { id: 'e', saved: true }],
-          dismissedMovies: [{ id: 'g', saved: true }, { id: 'h', saved: false }],
-        },
-      });
-    });
+    const UNDISMISS_MOVIE_API = '/api/secure/movies/a';
 
     describe('when the API call is successful', () => {
       beforeEach(() => {
-        fetchMock.mock('/api/secure/movies/g', 200);
-        fetchMock.mock('/api/secure/movies/h', 200);
+        fetchMock.mock(UNDISMISS_MOVIE_API, {
+          body: UPDATED_MOVIE,
+          status: 200,
+        });
       });
 
-      it('should return the correct actions (moviesQueue)', (done) => {
+      it('should return the correct actions', (done) => {
         const expectedActions = [
           { type: types.UNDISMISSING_MOVIE },
-          {
-            type: types.UNDISMISSED_MOVIE,
-            moviesQueue: [
-              { id: 'a', saved: false },
-              { id: 'b', saved: false },
-              { id: 'h', saved: false },
-            ],
-            savedMovies: [{ id: 'd', saved: true }, { id: 'e', saved: true }],
-            dismissedMovies: [{ id: 'g', saved: true }],
-          },
+          { type: types.UNDISMISSED_MOVIE, updatedMovie: UPDATED_MOVIE },
         ];
 
-        store.dispatch(movieActions.undismissMovie('h'))
-          .then(() => {
-            should(store.getActions()).deepEqual(expectedActions);
-          })
-          .then(done)   // testing complete
-          .catch(done); // we do this in case the tests fail, to end tests
-      });
-
-      it('should return the correct actions (savedMovies)', (done) => {
-        const expectedActions = [
-          { type: types.UNDISMISSING_MOVIE },
-          {
-            type: types.UNDISMISSED_MOVIE,
-            moviesQueue: [{ id: 'a', saved: false }, { id: 'b', saved: false }],
-            savedMovies: [
-              { id: 'd', saved: true },
-              { id: 'e', saved: true },
-              { id: 'g', saved: true },
-            ],
-            dismissedMovies: [{ id: 'h', saved: false }],
-          },
-        ];
-
-        store.dispatch(movieActions.undismissMovie('g'))
+        store.dispatch(movieActions.undismissMovie('a'))
           .then(() => {
             should(store.getActions()).deepEqual(expectedActions);
           })
@@ -217,11 +156,11 @@ describe('movieActions', () => {
 
     describe('when the API call fails (500)', () => {
       beforeEach(() => {
-        fetchMock.mock('/api/secure/movies/g', 500);
+        fetchMock.mock(UNDISMISS_MOVIE_API, 500);
       });
 
       it('should return the correct actions', (done) => {
-        store.dispatch(movieActions.undismissMovie('g'))
+        store.dispatch(movieActions.undismissMovie('a'))
           .then(() => {
             const actions = store.getActions();
 

--- a/test/app/reducers/movies.reducer.test.js
+++ b/test/app/reducers/movies.reducer.test.js
@@ -229,84 +229,92 @@ describe('movies reducer', () => {
     let state;
 
     beforeEach(() => {
-      state = reducer(undefined, {
-        type: types.MOVIES_QUEUE_LOADED,
-        moviesQueue: [{ a: 1 }],
-      });
-      state = reducer(state, {
-        type: types.SAVED_MOVIES_LOADED,
-        savedMovies: [{ b: 2 }],
-      });
-      state = reducer(state, {
-        type: types.DISMISSED_MOVIES_LOADED,
-        dismissedMovies: [{ c: 3 }],
-      });
+      state = reducer({
+        moviesQueue: [{ id: 'a' }],
+        savedMovies: [{ id: 'b', saved: true }],
+        dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
+      }, {});
     });
 
     it('should handle saved movie', () => {
       should(
         reducer(state, {
           type: types.SAVED_MOVIE,
-          moviesQueue: [{ x: 1 }],
-          savedMovies: [{ y: 2 }],
+          updatedMovie: { id: 'a' },
         })
       ).deepEqual({
         isWaiting: false,
-        moviesQueueSkip: 20,
-        moviesQueueLimit: 20,
-        moviesQueue: [{ x: 1 }],
-        savedMoviesSkip: 20,
-        savedMoviesLimit: 20,
-        savedMovies: [{ y: 2 }],
-        dismissedMoviesSkip: 20,
-        dismissedMoviesLimit: 20,
-        dismissedMovies: [{ c: 3 }],
+        moviesQueue: [],
+        savedMovies: [{ id: 'b', saved: true }, { id: 'a' }],
+        dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
         error: null,
       });
     });
 
-    it('should handle dismissed movie', () => {
+    it('should handle dismissed movie (moviesQueue)', () => {
       should(
         reducer(state, {
           type: types.DISMISSED_MOVIE,
-          moviesQueue: [{ x: 1 }],
-          savedMovies: [{ y: 2 }],
-          dismissedMovies: [{ z: 3 }],
+          updatedMovie: { id: 'a', dismissed: true },
         })
       ).deepEqual({
         isWaiting: false,
-        moviesQueueSkip: 20,
-        moviesQueueLimit: 20,
-        moviesQueue: [{ x: 1 }],
-        savedMoviesSkip: 20,
-        savedMoviesLimit: 20,
-        savedMovies: [{ y: 2 }],
-        dismissedMoviesSkip: 20,
-        dismissedMoviesLimit: 20,
-        dismissedMovies: [{ z: 3 }],
+        moviesQueue: [],
+        savedMovies: [{ id: 'b', saved: true }],
+        dismissedMovies: [
+          { id: 'c', dismissed: true },
+          { id: 'd', saved: true, dismissed: true },
+          { id: 'a', dismissed: true },
+        ],
         error: null,
       });
     });
 
-    it('should handle undismissed movie', () => {
+    it('should handle dismissed movie (savedMovies)', () => {
       should(
         reducer(state, {
-          type: types.UNDISMISSED_MOVIE,
-          moviesQueue: [{ x: 1 }],
-          savedMovies: [{ y: 2 }],
-          dismissedMovies: [{ z: 3 }],
+          type: types.DISMISSED_MOVIE,
+          updatedMovie: { id: 'b', saved: true, dismissed: true },
         })
       ).deepEqual({
         isWaiting: false,
-        moviesQueueSkip: 20,
-        moviesQueueLimit: 20,
-        moviesQueue: [{ x: 1 }],
-        savedMoviesSkip: 20,
-        savedMoviesLimit: 20,
-        savedMovies: [{ y: 2 }],
-        dismissedMoviesSkip: 20,
-        dismissedMoviesLimit: 20,
-        dismissedMovies: [{ z: 3 }],
+        moviesQueue: [{ id: 'a' }],
+        savedMovies: [],
+        dismissedMovies: [
+          { id: 'c', dismissed: true },
+          { id: 'd', saved: true, dismissed: true },
+          { id: 'b', saved: true, dismissed: true },
+        ],
+        error: null,
+      });
+    });
+
+    it('should handle undismissed movie (moviesQueue)', () => {
+      should(
+        reducer(state, {
+          type: types.UNDISMISSED_MOVIE,
+          updatedMovie: { id: 'c' },
+        })
+      ).deepEqual({
+        isWaiting: false,
+        moviesQueue: [{ id: 'a' }, { id: 'c' }],
+        savedMovies: [{ id: 'b', saved: true }],
+        dismissedMovies: [{ id: 'd', saved: true, dismissed: true }],
+        error: null,
+      });
+    });
+
+    it('should handle undismissed movie (savedMovies)', () => {
+      should(
+        reducer(state, {
+          type: types.UNDISMISSED_MOVIE,
+          updatedMovie: { id: 'd', saved: true },
+        })
+      ).deepEqual({
+        isWaiting: false,
+        moviesQueue: [{ id: 'a' }],
+        savedMovies: [{ id: 'b', saved: true }, { id: 'd', saved: true }],
+        dismissedMovies: [{ id: 'c', dismissed: true }],
         error: null,
       });
     });
@@ -319,15 +327,9 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
-        moviesQueueSkip: 20,
-        moviesQueueLimit: 20,
-        moviesQueue: [{ a: 1 }],
-        savedMoviesSkip: 20,
-        savedMoviesLimit: 20,
-        savedMovies: [{ b: 2 }],
-        dismissedMoviesSkip: 20,
-        dismissedMoviesLimit: 20,
-        dismissedMovies: [{ c: 3 }],
+        moviesQueue: [{ id: 'a' }],
+        savedMovies: [{ id: 'b', saved: true }],
+        dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
         error: 'bad',
       });
     });

--- a/test/server/lib/movies.test.js
+++ b/test/server/lib/movies.test.js
@@ -448,9 +448,27 @@ describe('The movies library', () => {
   });
 
   describe('update movie', () => {
+    let MOVIE;
     let Movie;
 
     beforeEach(() => {
+      MOVIE = {
+        _id: 'my-movie',
+        title: 'My Movie',
+        userScore: 100,
+        criticScore: 80,
+        tomatoIcon: 'certified',
+        mpaaRating: 'G',
+        runtime: '1 hour',
+        synopsis: 'Good things',
+        images: [
+          'one.jpg',
+          'two.jpg',
+        ],
+        saved: true,
+        dismissed: false,
+      };
+
       Movie = {
         _id: null,
         _updates: null,
@@ -459,7 +477,7 @@ describe('The movies library', () => {
           this._id = id;
           this._updates = updates;
           this._options = options;
-          return callback();
+          return callback(null, MOVIE);
         },
       };
 


### PR DESCRIPTION
Simplify the movie actions for save, dismiss, and un-dismiss by having it dispatch the updated movie to the reducer.  The reducer can then act on that action type given the updated movie.  This also will give us the updated movie details to add to the correct movies list.

Since we’re relying on getting back and movieUI object, update the movies lib to return the UI version of the object rather than the database version.