### PR TITLE
Disable class-name-format

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -13,6 +13,7 @@ rules:
     -
       style: 1tbs
       allow-single-line: false
+  class-name-format: 0
   clean-import-paths:
     - 0
   empty-line-between-blocks: 2


### PR DESCRIPTION
CSS modules needs the use of camel case class names, but at the same time we could possibly use other formats.  So disable to rule.