### PR TITLE
Test application

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,5 +130,17 @@ To run the mocha tests in a "watch" mode:
 
 `$ npm run test:watch`
 
+## Test App ##
+
+A test application is available to test out components used within the main
+application. To run the test app, execute the following command:
+
+`$ npm run test-app`
+
+The contents of the test application are not included in the webpack bundle
+used in the main application. The `TEST_APP` environment variable is used
+to determine which application `index.js` file to use, which imports in the
+necessary files.
+
 [travis-image]: https://img.shields.io/travis/dylants/watchlist/master.svg
 [travis-url]: https://travis-ci.org/dylants/watchlist

--- a/app/containers/test/test-app/test-app.container.js
+++ b/app/containers/test/test-app/test-app.container.js
@@ -1,0 +1,15 @@
+import React, { PropTypes } from 'react';
+
+import './test-app.container.scss';
+
+export default function TestApp({ children }) {
+  return (
+    <div>
+      {children}
+    </div>
+  );
+}
+
+TestApp.propTypes = {
+  children: PropTypes.any,
+};

--- a/app/containers/test/test-app/test-app.container.scss
+++ b/app/containers/test/test-app/test-app.container.scss
@@ -1,0 +1,10 @@
+@import 'normalize.css';
+
+* {
+  box-sizing: border-box;
+}
+
+.app {
+  font-family: 'Open Sans', sans-serif;
+  font-weight: 300;
+}

--- a/app/containers/test/test-home/test-home.container.js
+++ b/app/containers/test/test-home/test-home.container.js
@@ -1,0 +1,18 @@
+import React from 'react';
+import { Link } from 'react-router';
+
+import style from './test-home.container.scss';
+
+export default function TestHomeContainer() {
+  return (
+    <div className={style.home}>
+      <h1>Test Home</h1>
+      <ul className={style.list}>
+        <li className={style.listItem}><Link to="/link1">Awesome</Link></li>
+        <li className={style.listItem}><Link to="/link2">Sauce</Link></li>
+      </ul>
+    </div>
+  );
+}
+
+TestHomeContainer.propTypes = {};

--- a/app/containers/test/test-home/test-home.container.scss
+++ b/app/containers/test/test-home/test-home.container.scss
@@ -1,0 +1,17 @@
+.home {
+  margin-left: 25px;
+}
+
+.list {
+  list-style: circle;
+  padding-left: 20px;
+}
+
+.listItem {
+  margin-bottom: 10px;
+
+  a {
+    text-decoration: none;
+    color: initial;
+  }
+}

--- a/app/test-app-index.js
+++ b/app/test-app-index.js
@@ -1,0 +1,15 @@
+import React from 'react';
+import { render } from 'react-dom';
+import { Router, Route, IndexRoute, browserHistory } from 'react-router';
+
+import TestApp from './containers/test/test-app/test-app.container';
+import TestHomeContainer from './containers/test/test-home/test-home.container';
+
+render(
+  <Router history={browserHistory}>
+    <Route path="/" component={TestApp}>
+      <IndexRoute component={TestHomeContainer} />
+    </Route>
+  </Router>,
+  document.getElementById('app')
+);

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "production": "NODE_ENV=production node ./build/index.js",
     "test:mocha": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --recursive test/**",
     "test:watch": "NODE_ENV=test ./node_modules/.bin/mocha --compilers js:babel-core/register --recursive --watch test/**",
-    "test": "npm run lint && npm run test:mocha"
+    "test": "npm run lint && npm run test:mocha",
+    "test-app": "TEST_APP=true NODE_ENV=development ./node_modules/.bin/babel-node ./server/index.js"
   },
   "dependencies": {
     "async": "1.5.2",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -91,7 +91,12 @@ function getEntry() {
   }
 
   // add our entry point for the client web app
-  entry.push(path.join(appPath, 'index.js'));
+  // if TEST_APP then we build the test application, else the main one
+  if (process.env.TEST_APP) {
+    entry.push(path.join(appPath, 'test-app-index.js'));
+  } else {
+    entry.push(path.join(appPath, 'index.js'));
+  }
 
   return entry;
 }


### PR DESCRIPTION
Enable the use of a test application which can be used to test out components contained within the main application.  We key off the `TEST_APP` environment variable, and if set, set a different entry point in the webpack configuration.  This spiders out and loads a different set of files for the client bundle.  The inverse is then true — if we do _not_ set the `TEST_APP` environment variable, we don’t load the test application assets into the main bundle.

Nothing much in the test app as of yet, just a simple home page with a couple of links that don’t go anywhere.  Really just a proof of concept at this point.