### PR TITLE
Bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,10 @@ a list of those variables:
     `in-theaters` and `opening`, defaults to `in-theaters`.
     * `MOVIES_SORT_BY` : How to sort the movies retrieved, possible values
     include `popularity` and `release`, defaults to `popularity`.
+    * `MOVIES_REQUEST_ENCODING` : Encoding of the HTTP request, defaults to
+    `binary`. See
+    [the request options documentation](https://github.com/request/request#requestoptions-callback)
+    for more details.
 * Movie Filter - Attributes here define how the movies are filtered after they
 are retrieved from the movies API. These rules are listed in order of evaluation
 within the filter, so if a movie does not match the first rule, it can still

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -12,6 +12,7 @@ const config = {
     limit: process.env.MOVIES_LIMIT || 100,
     type: process.env.MOVIES_TYPE || 'in-theaters',
     sortBy: process.env.MOVIES_SORT_BY || 'popularity',
+    requestEncoding: process.env.MOVIES_REQUEST_ENCODING || 'binary',
   },
   movieFilter: {
     topMoviesIndex: process.env.TOP_MOVIES_INDEX || 0,

--- a/server/lib/movies.js
+++ b/server/lib/movies.js
@@ -12,11 +12,7 @@ const logger = require('./logger')();
  */
 function retrieveMovieData(callback) {
   // pull values from the config
-  const domain = config.movies.domain;
-  const api = config.movies.api;
-  const limit = config.movies.limit;
-  const type = config.movies.type;
-  const sortBy = config.movies.sortBy;
+  const { domain, api, limit, type, sortBy, requestEncoding } = config.movies;
 
   const url = `${domain}${api}?limit=${limit}&type=${type}&sortBy=${sortBy}`;
 
@@ -25,6 +21,7 @@ function retrieveMovieData(callback) {
     url,
     method: 'GET',
     json: true,
+    encoding: requestEncoding,
   }, (error, response, body) => {
     if (error) { return callback(error); }
 

--- a/setup.js
+++ b/setup.js
@@ -28,7 +28,7 @@ const user = new User({
 });
 user.save((err) => {
   if (err) {
-    logger.err(err);
+    logger.error(err);
   }
 
   process.exit();

--- a/test/app/reducers/movies.reducer.test.js
+++ b/test/app/reducers/movies.reducer.test.js
@@ -230,8 +230,14 @@ describe('movies reducer', () => {
 
     beforeEach(() => {
       state = reducer({
+        moviesQueueSkip: 20,
+        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }],
+        dismissedMoviesSkip: 20,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
       }, {});
     });
@@ -244,8 +250,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 19,
+        moviesQueueLimit: 20,
         moviesQueue: [],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }, { id: 'a' }],
+        dismissedMoviesSkip: 20,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
         error: null,
       });
@@ -259,8 +271,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 19,
+        moviesQueueLimit: 20,
         moviesQueue: [],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }],
+        dismissedMoviesSkip: 20,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [
           { id: 'c', dismissed: true },
           { id: 'd', saved: true, dismissed: true },
@@ -278,8 +296,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 20,
+        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }],
+        savedMoviesSkip: 19,
+        savedMoviesLimit: 20,
         savedMovies: [],
+        dismissedMoviesSkip: 20,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [
           { id: 'c', dismissed: true },
           { id: 'd', saved: true, dismissed: true },
@@ -297,8 +321,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 20,
+        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }, { id: 'c' }],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }],
+        dismissedMoviesSkip: 19,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'd', saved: true, dismissed: true }],
         error: null,
       });
@@ -312,8 +342,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 20,
+        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }, { id: 'd', saved: true }],
+        dismissedMoviesSkip: 19,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'c', dismissed: true }],
         error: null,
       });
@@ -327,8 +363,14 @@ describe('movies reducer', () => {
         })
       ).deepEqual({
         isWaiting: false,
+        moviesQueueSkip: 20,
+        moviesQueueLimit: 20,
         moviesQueue: [{ id: 'a' }],
+        savedMoviesSkip: 20,
+        savedMoviesLimit: 20,
         savedMovies: [{ id: 'b', saved: true }],
+        dismissedMoviesSkip: 20,
+        dismissedMoviesLimit: 20,
         dismissedMovies: [{ id: 'c', dismissed: true }, { id: 'd', saved: true, dismissed: true }],
         error: 'bad',
       });


### PR DESCRIPTION
* Use the `binary` HTTP request encoding to correctly load the data from the movies site.  Provide this as a configuration option.
* Reduce the skip amount in the movies state by 1 for the appropriate queue when a movie is saved/dismissed/undismissed.  This was done because we were altering the list in saving/dismissing/undismissing in removing something from a queue, and would then miss some movies when we’d request additional movies later.  By reducing the skip amount, we don’t miss those movies.
* Fix a typo in the setup to log errors correctly.