### PR TITLE
Movie trailer API

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,14 @@ be included by matching the next rule, and so on.
     the movie has not yet been included, defaults to `80`.
     * `MIN_USER_CRITIC_SCORE` : Minimum user AND critic score to include in
     the filter if the movie has not yet been included, defaults to `60`.
+* Movie Trailer API
+    * `MOVIE_TRAILER_DOMAIN` : The domain used to retrieve movie trailer data.
+    * `MOVIE_TRAILER_API` : The API (URL) used to retrieve movie trailer data.
+    * `MOVIE_TRAILER_API_MOVIE_ID_PLACEHOLDER` : The string placeholder within
+    the movie trailer API which should be replaced with the movie ID. Defaults
+    to `MOVIE_ID`.
+    * `MOVIE_TRAILER_LIMIT` : Limit the amount of trailers retrieved, defaults
+    to `1`.
 
 ## Tests ##
 

--- a/server/api/controllers/movies.controller.js
+++ b/server/api/controllers/movies.controller.js
@@ -8,6 +8,7 @@ import {
   enableSaved,
   enableDismissed,
   disableDismissed,
+  populateMovieTrailer,
 } from '../../lib/movies';
 
 function handleError(err, res) {
@@ -69,4 +70,14 @@ export function updateMovie(req, res) {
   } else {
     return res.status(400).end();
   }
+}
+
+export function addMovieTrailer(req, res) {
+  const movieId = req.params.movieId;
+
+  return populateMovieTrailer(movieId, (err, movie) => {
+    if (err) { return handleError(err, res); }
+
+    return res.send(movie);
+  });
 }

--- a/server/api/routes/movies.routes.js
+++ b/server/api/routes/movies.routes.js
@@ -2,11 +2,13 @@ import {
   getMovies,
   pullMovieData,
   updateMovie,
+  addMovieTrailer,
 } from '../controllers/movies.controller';
 
 module.exports = (router) => {
   router.route('/api/secure/movies').get(getMovies);
   router.route('/api/secure/movies/:movieId').patch(updateMovie);
+  router.route('/api/secure/movies/:movieId/trailer').post(addMovieTrailer);
 
   router.route('/api/secure/download-movie-data').get(pullMovieData);
 };

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -20,6 +20,12 @@ const config = {
     minCriticScore: process.env.MIN_CRITIC_SCORE || 80,
     minUserCriticScore: process.env.MIN_USER_CRITIC_SCORE || 60,
   },
+  movieTrailer: {
+    domain: process.env.MOVIE_TRAILER_DOMAIN || 'https://www.rottentomatoes.com',
+    api: process.env.MOVIE_TRAILER_API || '/api/private/v1.1a/movies/MOVIE_ID/videos.json',
+    apiMovieIdPlaceholder: process.env.MOVIE_TRAILER_API_MOVIE_ID_PLACEHOLDER || 'MOVIE_ID',
+    limit: process.env.MOVIE_TRAILER_LIMIT || 1,
+  },
 };
 
 export default config;

--- a/server/models/movie.js
+++ b/server/models/movie.js
@@ -20,6 +20,8 @@ const MovieSchema = new Schema({
   synopsis: String,
   images: Array,
   url: String,
+  remoteId: Number,
+  trailerUrl: String,
 
   // user interactions
   saved: Boolean,

--- a/test/server/lib/movies.test.js
+++ b/test/server/lib/movies.test.js
@@ -92,6 +92,7 @@ describe('The movies library', () => {
             criticScore: 13,
             tomatoIcon: 'rotten',
             mpaaRating: 'PG-13',
+            remoteId: 771376964,
             runtime: '1 hr. 42 min.',
             theaterReleaseDate: 'Jan 15',
             synopsis: 'Ride Along 2 presents a cop-comedy sequel whose well-matched stars...',
@@ -107,6 +108,7 @@ describe('The movies library', () => {
             criticScore: 82,
             tomatoIcon: 'certified',
             mpaaRating: 'R',
+            remoteId: 771379020,
             runtime: '2 hr. 36 min.',
             theaterReleaseDate: 'Dec 25',
             synopsis: 'As starkly beautiful as it is harshly uncompromising, The Revenant uses...',
@@ -346,6 +348,7 @@ describe('The movies library', () => {
           'one.jpg',
           'two.jpg',
         ],
+        trailerUrl: 'http://123.com',
         saved: true,
         dismissed: false,
       })).should.deepEqual({
@@ -358,6 +361,7 @@ describe('The movies library', () => {
         runtime: '1 hour',
         synopsis: 'Good things',
         image: 'one.jpg',
+        trailerUrl: 'http://123.com',
         saved: true,
         dismissed: false,
       });
@@ -383,6 +387,7 @@ describe('The movies library', () => {
         runtime: '1 hour',
         synopsis: 'Good things',
         image: null,
+        trailerUrl: null,
         saved: false,
         dismissed: false,
       });
@@ -447,9 +452,12 @@ describe('The movies library', () => {
     });
   });
 
-  describe('update movie', () => {
+  describe('update movie functions', () => {
     let MOVIE;
     let Movie;
+    let TRAILER_URL;
+    let request;
+    let requestOptions;
 
     beforeEach(() => {
       MOVIE = {
@@ -460,6 +468,7 @@ describe('The movies library', () => {
         tomatoIcon: 'certified',
         mpaaRating: 'G',
         runtime: '1 hour',
+        remoteId: 987654322,
         synopsis: 'Good things',
         images: [
           'one.jpg',
@@ -479,9 +488,26 @@ describe('The movies library', () => {
           this._options = options;
           return callback(null, MOVIE);
         },
+        findById(id, callback) {
+          return callback(null, MOVIE);
+        },
       };
 
       moviesLib.__set__('Movie', Movie);
+
+      TRAILER_URL = 'http://123.com';
+
+      request = (options, callback) => {
+        requestOptions = options;
+        return callback(null, null, {
+          mainTrailer: {
+            mp4Url: TRAILER_URL,
+          },
+        });
+      };
+      requestOptions = null;
+
+      moviesLib.__set__('request', request);
     });
 
     describe('enableSaved', () => {
@@ -518,6 +544,21 @@ describe('The movies library', () => {
           should(Movie._id).equal('123');
           should(Movie._updates).deepEqual({
             dismissed: false,
+          });
+          should(Movie._options).deepEqual({
+            new: true,
+          });
+        });
+      });
+    });
+
+    describe('populateMovieTrailer', () => {
+      it('should work', () => {
+        moviesLib.populateMovieTrailer('123', () => {
+          should(_.includes(requestOptions.url, MOVIE.remoteId)).be.true();
+          should(Movie._id).equal('123');
+          should(Movie._updates).deepEqual({
+            trailerUrl: TRAILER_URL,
           });
           should(Movie._options).deepEqual({
             new: true,


### PR DESCRIPTION
Add an API which can “create” a movie trailer for a movie.

Now, when we load the movie details, we’ll also grab the remote ID for the movie document.  We store this to be used later.  We also allow storing a `trailerUrl` in the movie document.

If the user wishes to POST a request for a movie trailer, we’ll use that remote ID to query the movie trailer API to pull down a movie trailer URL.  We can then take that URL and update the movie document to include this `trailerUrl`.