### PR TITLE
Webpack updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "eslint-plugin-react": "5.1.1",
     "extract-text-webpack-plugin": "1.0.1",
     "fetch-mock": "4.5.0",
+    "git-rev-sync": "1.6.0",
     "html-webpack-plugin": "2.17.0",
     "mocha": "2.4.5",
     "node-sass": "3.7.0",

--- a/package.json
+++ b/package.json
@@ -67,6 +67,7 @@
     "eslint-plugin-import": "1.8.0",
     "eslint-plugin-jsx-a11y": "1.2.0",
     "eslint-plugin-react": "5.1.1",
+    "extract-text-webpack-plugin": "1.0.1",
     "fetch-mock": "4.5.0",
     "html-webpack-plugin": "2.17.0",
     "mocha": "2.4.5",

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "debug-caller": "2.1.0",
     "express": "4.13.4",
     "glob": "7.0.3",
-    "isomorphic-fetch": "2.2.1",
     "lodash": "4.12.0",
     "mongoose": "4.4.17",
     "normalize.css": "4.1.1",
@@ -50,7 +49,8 @@
     "redux-logger": "2.6.1",
     "redux-thunk": "2.1.0",
     "request": "2.72.0",
-    "slug": "0.9.1"
+    "slug": "0.9.1",
+    "whatwg-fetch": "1.0.0"
   },
   "devDependencies": {
     "babel-cli": "6.8.0",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,6 +4,7 @@
 
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const ExtractTextPlugin = require('extract-text-webpack-plugin');
 const path = require('path');
 
 // default the environment to development
@@ -43,6 +44,10 @@ function getPlugins() {
       minimize: true,
       sourceMap: true,
     }));
+
+    // https://webpack.github.io/docs/stylesheets.html
+    // https://github.com/webpack/extract-text-webpack-plugin
+    plugins.push(new ExtractTextPlugin('[name]-[hash].min.css'));
   } else {
     // http://webpack.github.io/docs/list-of-plugins.html#hotmodulereplacementplugin
     plugins.push(new webpack.HotModuleReplacementPlugin());
@@ -52,6 +57,28 @@ function getPlugins() {
 }
 
 function getLoaders() {
+  // https://github.com/webpack/style-loader
+  const styleLoaderConfig = 'style';
+  // https://github.com/webpack/css-loader
+  const cssLoaderConfig = 'css' +
+    '?modules' +
+    '&sourceMap' +
+    '&localIdentName=[local]___[hash:base64:5]';
+  // https://github.com/jtangelder/sass-loader
+  const sassLoaderConfig = 'sass' +
+    '?outputStyle=expanded' +
+    '&sourceMap';
+
+  let cssLoaders;
+  if (IS_PRODUCTION) {
+    // https://github.com/webpack/extract-text-webpack-plugin
+    cssLoaders = ExtractTextPlugin.extract(
+      `${cssLoaderConfig}!${sassLoaderConfig}`
+    );
+  } else {
+    cssLoaders = `${styleLoaderConfig}!${cssLoaderConfig}!${sassLoaderConfig}`;
+  }
+
   const loaders = [
     {
       test: /\.js$/,
@@ -63,14 +90,7 @@ function getLoaders() {
     }, {
       test: /(\.scss)$/,
       exclude: /node_modules/,
-      loader: 'style' +
-              '!' +
-              'css?modules' +
-                '&sourceMap' +
-                '&localIdentName=[local]___[hash:base64:5]' +
-              '!' +
-              'sass?outputStyle=expanded' +
-                '&sourceMap',
+      loader: cssLoaders,
     }, {
       test: /\.js$/,
       exclude: /node_modules/,

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,6 +5,7 @@
 const webpack = require('webpack');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ExtractTextPlugin = require('extract-text-webpack-plugin');
+const git = require('git-rev-sync');
 const path = require('path');
 
 // default the environment to development
@@ -13,6 +14,7 @@ const IS_PRODUCTION = NODE_ENV === 'production';
 const appPath = path.join(__dirname, 'app');
 const assetsPath = path.join(__dirname, 'public');
 const publicPath = '/';
+const GIT_REVISION = git.long();
 
 function getPlugins() {
   // These plugins are used in all environments
@@ -47,7 +49,7 @@ function getPlugins() {
 
     // https://webpack.github.io/docs/stylesheets.html
     // https://github.com/webpack/extract-text-webpack-plugin
-    plugins.push(new ExtractTextPlugin('[name]-[hash].min.css'));
+    plugins.push(new ExtractTextPlugin(`[name]-${GIT_REVISION}.min.css`));
   } else {
     // http://webpack.github.io/docs/list-of-plugins.html#hotmodulereplacementplugin
     plugins.push(new webpack.HotModuleReplacementPlugin());
@@ -133,7 +135,7 @@ function getOutput() {
     output = {
       path: assetsPath,
       publicPath,
-      filename: '[name]-[hash].min.js',
+      filename: `[name]-${GIT_REVISION}.min.js`,
     };
   } else {
     output = {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -84,6 +84,10 @@ function getLoaders() {
 function getEntry() {
   const entry = [];
 
+  // https://github.com/github/fetch
+  // fetch polyfill to support older browsers
+  entry.push('whatwg-fetch');
+
   // hot reload only when in non-production environment
   if (!IS_PRODUCTION) {
     // https://github.com/glenjamin/webpack-hot-middleware#config

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -112,6 +112,7 @@ function getOutput() {
   if (IS_PRODUCTION) {
     output = {
       path: assetsPath,
+      publicPath,
       filename: '[name]-[hash].min.js',
     };
   } else {


### PR DESCRIPTION
**Add fetch polyfill**

Add `whatwg-fetch` (as a fetch polyfill) to support older browsers. Remove the `isomorphic-fetch` since we’re no longer using it.

**Provide path for assets in production**

Include the `publicPath` within the `output` configuration for webpack to provide a path (instead of using relative paths).  This fixes refresh on pages that are not the index (`/`) page.

**Extract CSS in production**

When running webpack in the production environment, extract out the CSS instead of using the `style` loader.

**Git revision client assets for production**

Include the `git-rev-sync` dependency and use it to create the production assets.  This will help us know which version of the app is running in production.