### PR TITLE
Use single file for action types

### DIFF
--- a/app/action-types/login.action-types.js
+++ b/app/action-types/login.action-types.js
@@ -1,3 +1,0 @@
-export const LOGIN_INITIATED = 'LOGIN_INITIATED';
-export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
-export const LOGIN_ERROR = 'LOGIN_ERROR';

--- a/app/actions/dismissed-movies.actions.js
+++ b/app/actions/dismissed-movies.actions.js
@@ -11,7 +11,7 @@ import {
   DISMISSED_MOVIES_LOADED,
   MOVIES_ALREADY_LOADED,
   FAILED_LOADING_MOVIES,
-} from '../action-types/movie.action-types';
+} from '../constants/action-types';
 
 function loadingMovies() {
   return { type: LOADING_MOVIES };

--- a/app/actions/login.actions.js
+++ b/app/actions/login.actions.js
@@ -5,7 +5,7 @@ import {
   LOGIN_INITIATED,
   LOGIN_SUCCESS,
   LOGIN_ERROR,
-} from '../action-types/login.action-types';
+} from '../constants/action-types';
 
 function loginInitiated() {
   return { type: LOGIN_INITIATED };

--- a/app/actions/movie.actions.js
+++ b/app/actions/movie.actions.js
@@ -12,7 +12,7 @@ import {
   UNDISMISSED_MOVIE,
   UNDISMISSING_MOVIE,
   FAILED_UPDATING_MOVIE,
-} from '../action-types/movie.action-types';
+} from '../constants/action-types';
 
 function savingMovie() {
   return { type: SAVING_MOVIE };

--- a/app/actions/movies-queue.actions.js
+++ b/app/actions/movies-queue.actions.js
@@ -11,7 +11,7 @@ import {
   MOVIES_QUEUE_LOADED,
   MOVIES_ALREADY_LOADED,
   FAILED_LOADING_MOVIES,
-} from '../action-types/movie.action-types';
+} from '../constants/action-types';
 
 function loadingMovies() {
   return { type: LOADING_MOVIES };

--- a/app/actions/saved-movies.actions.js
+++ b/app/actions/saved-movies.actions.js
@@ -11,7 +11,7 @@ import {
   SAVED_MOVIES_LOADED,
   MOVIES_ALREADY_LOADED,
   FAILED_LOADING_MOVIES,
-} from '../action-types/movie.action-types';
+} from '../constants/action-types';
 
 function loadingMovies() {
   return { type: LOADING_MOVIES };

--- a/app/constants/action-types.js
+++ b/app/constants/action-types.js
@@ -1,3 +1,13 @@
+/*
+ * LOGIN
+ */
+export const LOGIN_INITIATED = 'LOGIN_INITIATED';
+export const LOGIN_SUCCESS = 'LOGIN_SUCCESS';
+export const LOGIN_ERROR = 'LOGIN_ERROR';
+
+/*
+ * MOVIE
+ */
 export const LOADING_MOVIES = 'LOADING_MOVIES';
 export const MOVIES_QUEUE_LOADED = 'MOVIES_QUEUE_LOADED';
 export const SAVED_MOVIES_LOADED = 'SAVED_MOVIES_LOADED';

--- a/app/reducers/login.reducer.js
+++ b/app/reducers/login.reducer.js
@@ -2,7 +2,7 @@ import {
   LOGIN_INITIATED,
   LOGIN_SUCCESS,
   LOGIN_ERROR,
-} from '../action-types/login.action-types';
+} from '../constants/action-types';
 
 const initialState = {
   isWaiting: false,

--- a/app/reducers/movies.reducer.js
+++ b/app/reducers/movies.reducer.js
@@ -14,7 +14,7 @@ import {
   UNDISMISSED_MOVIE,
   UNDISMISSING_MOVIE,
   FAILED_UPDATING_MOVIE,
-} from '../action-types/movie.action-types';
+} from '../constants/action-types';
 
 const initialState = {
   isWaiting: false,

--- a/test/app/actions/dismissed-movies.actions.test.js
+++ b/test/app/actions/dismissed-movies.actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as dismissedMoviesActions from '../../../app/actions/dismissed-movies.actions';
-import * as types from '../../../app/action-types/movie.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 const fetchMock = require('fetch-mock');

--- a/test/app/actions/login.actions.test.js
+++ b/test/app/actions/login.actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as loginActions from '../../../app/actions/login.actions';
-import * as types from '../../../app/action-types/login.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 const fetchMock = require('fetch-mock');

--- a/test/app/actions/movie.actions.test.js
+++ b/test/app/actions/movie.actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as movieActions from '../../../app/actions/movie.actions';
-import * as types from '../../../app/action-types/movie.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 const fetchMock = require('fetch-mock');

--- a/test/app/actions/movies-queue.actions.test.js
+++ b/test/app/actions/movies-queue.actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as moviesQueueActions from '../../../app/actions/movies-queue.actions';
-import * as types from '../../../app/action-types/movie.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 const fetchMock = require('fetch-mock');

--- a/test/app/actions/saved-movies.actions.test.js
+++ b/test/app/actions/saved-movies.actions.test.js
@@ -1,7 +1,7 @@
 import configureMockStore from 'redux-mock-store';
 import thunk from 'redux-thunk';
 import * as savedMoviesActions from '../../../app/actions/saved-movies.actions';
-import * as types from '../../../app/action-types/movie.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 const fetchMock = require('fetch-mock');

--- a/test/app/reducers/login.reducer.test.js
+++ b/test/app/reducers/login.reducer.test.js
@@ -1,5 +1,5 @@
 import reducer from '../../../app/reducers/login.reducer';
-import * as types from '../../../app/action-types/login.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 describe('login reducer', () => {

--- a/test/app/reducers/movies.reducer.test.js
+++ b/test/app/reducers/movies.reducer.test.js
@@ -1,5 +1,5 @@
 import reducer from '../../../app/reducers/movies.reducer';
-import * as types from '../../../app/action-types/movie.action-types';
+import * as types from '../../../app/constants/action-types';
 import should from 'should';
 
 describe('movies reducer', () => {


### PR DESCRIPTION
To minimize possible problems in sharing state (between reducers), combine the action types into a single file.  This way we have a common understanding of all the actions expressed in the application and won’t accidentally invoke one that is used by another.

This will close #33 