### PR TITLE
Remove stale movies

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,12 @@ be included by matching the next rule, and so on.
     to `MOVIE_ID`.
     * `MOVIE_TRAILER_LIMIT` : Limit the amount of trailers retrieved, defaults
     to `1`.
+* Movie Cleanup
+    * `MOVIE_CLEANUP_MODIFIED_DAYS_AGO` : Dismissed movies that have NOT been
+    modified as recently as this many days ago will be deleted. For example,
+    the default value is `5`, meaning dismissed movies that have not been
+    updated in 5 days (either by a movie update or a user action) will be
+    removed at next scheduled cleanup.
 
 ## Tests ##
 

--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "express": "4.13.4",
     "glob": "7.0.3",
     "lodash": "4.12.0",
+    "moment": "2.13.0",
     "mongoose": "4.4.17",
     "normalize.css": "4.1.1",
     "passport": "0.3.2",

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -26,6 +26,9 @@ const config = {
     apiMovieIdPlaceholder: process.env.MOVIE_TRAILER_API_MOVIE_ID_PLACEHOLDER || 'MOVIE_ID',
     limit: process.env.MOVIE_TRAILER_LIMIT || 1,
   },
+  movieCleanup: {
+    modifiedDaysAgo: process.env.MOVIE_CLEANUP_MODIFIED_DAYS_AGO || 5,
+  },
 };
 
 export default config;

--- a/server/models/plugins/created-modified.js
+++ b/server/models/plugins/created-modified.js
@@ -19,4 +19,14 @@ module.exports = function createdModifiedPlugin(schema) {
 
     next();
   });
+
+  schema.pre('findOneAndUpdate', function update() {
+    /*
+     * When updating, we want to update the modified timestamp. We do so by
+     * executing another update call per the docs:
+     * http://mongoosejs.com/docs/middleware.html
+     * http://github.com/Automattic/mongoose/issues/964
+     */
+    this.findOneAndUpdate({}, { modified: new Date() });
+  });
 };

--- a/test/server/lib/movies.test.js
+++ b/test/server/lib/movies.test.js
@@ -567,4 +567,42 @@ describe('The movies library', () => {
       });
     });
   });
+
+  describe('removeStaleMovies', () => {
+    let DETAILS;
+    let Movie;
+
+    beforeEach(() => {
+      DETAILS = {
+        result: {
+          ok: 1,
+          n: 3,
+        },
+      };
+
+      Movie = {
+        _options: null,
+        remove(options, callback) {
+          this._options = options;
+          return callback(null, DETAILS);
+        },
+      };
+
+      moviesLib.__set__('Movie', Movie);
+    });
+
+    it('should work', (done) => {
+      moviesLib.removeStaleMovies((err, numRemoved) => {
+        should(Movie._options).be.ok();
+        should(Movie._options.dismissed).be.true();
+        should(Movie._options.modified).be.ok();
+        should(Movie._options.modified.$lt).be.ok();
+
+        should(err).be.null();
+        should(numRemoved).equal(3);
+
+        done();
+      });
+    });
+  });
 });


### PR DESCRIPTION
Add the ability to remove movies which are both `dismissed` and have not been modified recently (as determined by the configuration).  This allows us to cleanup old movies which are dismissed by the user and not updated by the movies API.

To help in this new feature, we must update the `created-modified` mongoose plugin to get a pre update hook in place to correctly update the movies `modified` flag.