### PR TITLE
Updates to header, movie, and config

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,8 @@
 
 What to watch.
 
+<img src="https://camo.githubusercontent.com/8887b11a967e7424105a6bcf8ceba86fd370d2e9/68747470733a2f2f73332e616d617a6f6e6177732e636f6d2f64796c616e74732d77617463686c6973742f7075626c69632f696d616765732f73637265656e73686f742e706e67">
+
 ## Overview ##
 
 The intent of this web application is to regularly download metadata about
@@ -49,12 +51,32 @@ machine. A recommended install method is to use
 [nvm](https://github.com/creationix/nvm) which installs Node into your
 home directory.
 
+This project requires Node v4 or above, recommended v6.
+
 ### Install Dependencies ###
 
 Once Node is installed, from this project's root directory run the following
 command to install the project dependencies:
 
 `$ npm install`
+
+### MongoDB ###
+
+This application requires a connection to a
+[Mongo Database](https://www.mongodb.com/). This database can be run locally
+or remotely, with the connection information specified in the configuration
+or in environment variables at startup time. For more information on the
+configuration parameters, please see the [Configuration](#configuration)
+section.
+
+### Create User ###
+
+This application requires an authenticated user to access the APIs. A script
+is available in the root of this project to create a user to use locally if
+needed. Edit the `setup.js` file in the project root to suite your needs, and
+once ready, run the following command to populate the user:
+
+`$ node setup.js`
 
 ### Start the App ###
 
@@ -165,8 +187,8 @@ be included by matching the next rule, and so on.
 * Movie Cleanup
     * `MOVIE_CLEANUP_MODIFIED_DAYS_AGO` : Dismissed movies that have NOT been
     modified as recently as this many days ago will be deleted. For example,
-    the default value is `5`, meaning dismissed movies that have not been
-    updated in `5` days (either by a movie update or a user action) will be
+    the default value is `90`, meaning dismissed movies that have not been
+    updated in `90` days (either by a movie update or a user action) will be
     removed at next scheduled cleanup.
 
 ## Tests ##

--- a/app/components/header/header.component.js
+++ b/app/components/header/header.component.js
@@ -3,16 +3,38 @@ import React, { PropTypes } from 'react';
 import style from './header.component.scss';
 
 export default function Header(props) {
+  let queueClass;
+  let savedClass;
+  let dismissedClass;
+
+  // default each class to the basic element styling
+  queueClass = savedClass = dismissedClass = style.element;
+
+  // assign a selected class based on who's selected
+  switch (props.selected) {
+    case 'queue':
+      queueClass = `${queueClass} ${style.selected}`;
+      break;
+    case 'saved':
+      savedClass = `${savedClass} ${style.selected}`;
+      break;
+    case 'dismissed':
+      dismissedClass = `${dismissedClass} ${style.selected}`;
+      break;
+    default:
+  }
+
   return (
     <div className={style.header}>
-      <div className={style.element} onClick={props.clickQueue}>Queue</div>
-      <div className={style.element} onClick={props.clickSaved}>Saved</div>
-      <div className={style.element} onClick={props.clickDismissed}>Dismissed</div>
+      <div className={queueClass} onClick={props.clickQueue}>Queue</div>
+      <div className={savedClass} onClick={props.clickSaved}>Saved</div>
+      <div className={dismissedClass} onClick={props.clickDismissed}>Dismissed</div>
     </div>
   );
 }
 
 Header.propTypes = {
+  selected: PropTypes.string.isRequired,
   clickQueue: PropTypes.func.isRequired,
   clickSaved: PropTypes.func.isRequired,
   clickDismissed: PropTypes.func.isRequired,

--- a/app/components/header/header.component.scss
+++ b/app/components/header/header.component.scss
@@ -12,6 +12,16 @@
   border-bottom: 1px solid $swatch01;
 }
 
+$selected-size: 2px;
+
 .element {
+  padding-left: 5px;
+  padding-right: 5px;
+  padding-bottom: $selected-size;
   cursor: pointer;
+}
+
+.selected {
+  border-bottom: $selected-size solid $swatch02;
+  padding-bottom: 0;
 }

--- a/app/components/movie/movie.component.scss
+++ b/app/components/movie/movie.component.scss
@@ -10,6 +10,7 @@
 
 .image {
   height: 300px;
+  max-width: 205px;
   margin-bottom: 20px;
 }
 
@@ -75,13 +76,13 @@
 }
 
 .synopsisContentWrapper {
-  max-height: 30px;
+  max-height: 80px;
   overflow-y: hidden;
   transition: max-height 500ms ease-in-out;
 }
 
 .showMore {
-  max-height: 1000px;
+  max-height: 2000px;
 }
 
 .synopsisContent {

--- a/app/containers/app/app.container.js
+++ b/app/containers/app/app.container.js
@@ -9,7 +9,7 @@ export default function App({ children, location }) {
   let header;
   if (location.pathname !== '/login') {
     header = (
-      <HeaderContainer />
+      <HeaderContainer location={location} />
     );
   }
 

--- a/app/containers/header/header.container.js
+++ b/app/containers/header/header.container.js
@@ -1,11 +1,28 @@
-import React from 'react';
+import React, { PropTypes } from 'react';
 import { browserHistory } from 'react-router';
 
 import Header from '../../components/header/header.component';
 
 export default function HeaderContainer() {
+  let selected;
+
+  // determine the current selected element
+  switch (location.pathname) {
+    case '/':
+      selected = 'queue';
+      break;
+    case '/saved':
+      selected = 'saved';
+      break;
+    case '/dismissed':
+      selected = 'dismissed';
+      break;
+    default:
+  }
+
   return (
     <Header
+      selected={selected}
       clickQueue={() => browserHistory.push('/')}
       clickSaved={() => browserHistory.push('/saved')}
       clickDismissed={() => browserHistory.push('/dismissed')}
@@ -13,4 +30,6 @@ export default function HeaderContainer() {
   );
 }
 
-HeaderContainer.propTypes = {};
+HeaderContainer.propTypes = {
+  location: PropTypes.object.isRequired,
+};

--- a/app/containers/test/header-test/header-test.container.js
+++ b/app/containers/test/header-test/header-test.container.js
@@ -1,0 +1,28 @@
+import React, { Component } from 'react';
+
+import Header from '../../../components/header/header.component';
+
+export default class HeaderTestContainer extends Component {
+  state = {
+    selected: 'queue',
+  };
+
+  click = (element) => {
+    this.setState({
+      selected: element,
+    });
+  }
+
+  render() {
+    return (
+      <div>
+        <Header
+          selected={this.state.selected}
+          clickQueue={() => this.click('queue')}
+          clickSaved={() => this.click('saved')}
+          clickDismissed={() => this.click('dismissed')}
+        />
+      </div>
+    );
+  }
+}

--- a/app/containers/test/movie-test/movie-test.container.js
+++ b/app/containers/test/movie-test/movie-test.container.js
@@ -5,7 +5,7 @@ import Movie from '../../../components/movie/movie.component';
 import style from './movie-test.container.scss';
 
 export default function MovieTestContainer() {
-  const image = 'http://www.rottentomatoes.com/static/images/redesign/poster_default.gif';
+  const image = 'http://www.fillmurray.com/206/300';
   const synopsis1 = 'Voluptas odit explicabo atque mollitia occaecati sunt. Non ' +
     'esse nostrum doloremque officiis. Dolor voluptatibus fugit cumque soluta.';
   const synopsis2 = 'Nemo est voluptatem non odio voluptatem fugit. Iste ' +

--- a/app/containers/test/test-home/test-home.container.js
+++ b/app/containers/test/test-home/test-home.container.js
@@ -8,6 +8,7 @@ export default function TestHomeContainer() {
     <div className={style.home}>
       <h1>Test Home</h1>
       <ul className={style.list}>
+        <li className={style.listItem}><Link to="/header">Header</Link></li>
         <li className={style.listItem}><Link to="/movie">Movie</Link></li>
         <li className={style.listItem}><Link to="/movies">Movies</Link></li>
       </ul>

--- a/app/index.js
+++ b/app/index.js
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render } from 'react-dom';
 import { Provider } from 'react-redux';
-import { Router, Route, IndexRoute, browserHistory } from 'react-router';
+import { Router, Route, browserHistory } from 'react-router';
 import { syncHistoryWithStore } from 'react-router-redux';
 
 import configureStore from './store/configureStore';
@@ -18,8 +18,8 @@ const history = syncHistoryWithStore(browserHistory, store);
 render(
   <Provider store={store}>
     <Router history={history}>
-      <Route path="/" component={App}>
-        <IndexRoute component={MoviesQueueContainer} />
+      <Route component={App}>
+        <Route path="/" component={MoviesQueueContainer} />
         <Route path="saved" component={SavedMoviesContainer} />
         <Route path="dismissed" component={DismissedMoviesContainer} />
         <Route path="login" component={LoginContainer} />

--- a/app/test-app-index.js
+++ b/app/test-app-index.js
@@ -1,16 +1,18 @@
 import React from 'react';
 import { render } from 'react-dom';
-import { Router, Route, IndexRoute, browserHistory } from 'react-router';
+import { Router, Route, browserHistory } from 'react-router';
 
 import TestApp from './containers/test/test-app/test-app.container';
 import TestHomeContainer from './containers/test/test-home/test-home.container';
+import HeaderTestContainer from './containers/test/header-test/header-test.container';
 import MovieTestContainer from './containers/test/movie-test/movie-test.container';
 import MoviesTestContainer from './containers/test/movies-test/movies-test.container';
 
 render(
   <Router history={browserHistory}>
-    <Route path="/" component={TestApp}>
-      <IndexRoute component={TestHomeContainer} />
+    <Route component={TestApp}>
+      <Route path="/" component={TestHomeContainer} />
+      <Route path="/header" component={HeaderTestContainer} />
       <Route path="/movie" component={MovieTestContainer} />
       <Route path="/movies" component={MoviesTestContainer} />
     </Route>

--- a/server/config/index.js
+++ b/server/config/index.js
@@ -31,7 +31,7 @@ const config = {
     limit: process.env.MOVIE_TRAILER_LIMIT || 1,
   },
   movieCleanup: {
-    modifiedDaysAgo: process.env.MOVIE_CLEANUP_MODIFIED_DAYS_AGO || 5,
+    modifiedDaysAgo: process.env.MOVIE_CLEANUP_MODIFIED_DAYS_AGO || 90,
   },
 };
 


### PR DESCRIPTION
- Provide a visible indicator of what page the user is on within the header component, via a `selected` prop.
- Create a header test component to view the header component in the test application
- Minor styling tweaks to the movie component and movie test container
- Change the movie cleanup days to 90 to try to align with how long these movies stay in the remote movie APIs.  If we delete them too soon, we’ll just re-import them again on the next download.  So retain them for a while in their state (probably dismissed) until they are hopefully removed from the remote servers.
- Readme updates to include additional setup instructions and a demo image.